### PR TITLE
Topic specific paragraphs

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -37,7 +37,6 @@ body{
     color:#c9c1b6;
 }
 
-
 .palette-darkgray{
     color: #403b35;
 }

--- a/js/UserTopicService.js
+++ b/js/UserTopicService.js
@@ -61,7 +61,7 @@ function globalTopicChanges() {
 
     console.log("imgSpanElements clicked", imgSpanElements)
 
-// All text with class "globalTopic" changes to new topic name
+    // All text with class "globalTopic" changes to new topic name
     const vis4SpanElements = document.querySelectorAll('.globalTopic');
     vis4SpanElements.forEach(spanElement => {
         spanElement.textContent = userTopic;
@@ -72,41 +72,26 @@ function globalTopicChanges() {
         spanElement.textContent = emojiName;
     });
 
-    toggleParagraphVisibility();
+    hideAllEmojiSpecificParagraphs()
+    showEmojiSpecificParagraphs(emojiName)
 }
 
 function vis4TopicChanges() {
     console.log("vis4TopicChanges clicked", userTopic)
     vis4Race.wrangleData();
-
 }
 
-function toggleParagraphVisibility() {
-    var topicEmmett = document.getElementById('topic-emmett');
-    var topicHerbie = document.getElementById('topic-herbie');
-    var topicSunny = document.getElementById('topic-sunny');
-    var topicOscar = document.getElementById('topic-oscar');
-
-    // Hide all paragraphs initially
-    topicEmmett.classList.add('d-none');
-    topicHerbie.classList.add('d-none');
-    topicSunny.classList.add('d-none');
-    topicOscar.classList.add('d-none');
-
-    // Show the appropriate paragraph based on emojiName
-    if (emojiName === 'Emmett') {
-        topicEmmett.classList.remove('d-none');
-    } else if (emojiName === 'Herbie') {
-        topicHerbie.classList.remove('d-none');
-    } else if (emojiName === 'Sunny') {
-        topicSunny.classList.remove('d-none');
-    } else if (emojiName === 'Oscar') {
-        topicOscar.classList.remove('d-none');
-    }
+function hideAllEmojiSpecificParagraphs() {
+    const emojiParagraphElements = document.querySelectorAll('.topic-emmett, .topic-herbie, .topic-sunny, .topic-oscar');
+    emojiParagraphElements.forEach(paragraphElement => {
+        paragraphElement.style.display = 'none';
+    });
 }
 
-
-
-
-
-
+function showEmojiSpecificParagraphs(emojiName) {
+    const selector = '.topic-' + emojiName.toLowerCase()
+    const topicParagraphElements = document.querySelectorAll(selector);
+    topicParagraphElements.forEach(paragraphElement => {
+        paragraphElement.style.display = 'block';
+    });
+}

--- a/js/Vis2Service.js
+++ b/js/Vis2Service.js
@@ -53,6 +53,10 @@ yearDropdown.addEventListener('change', function() {
 //     toggleDropdown('topic-selector'); // Call this function when topic-selector is clicked
 // });
 
+//Initial conditions:
+// Initial hide of the "Next" and "Back" buttons
+nextButton.style.display = "block";
+backButton.style.display = "none";
 
 nextButton.onclick = function() {
     subjectIndex = Math.min(subjects.length -1, subjectIndex + 1);
@@ -63,7 +67,7 @@ nextButton.onclick = function() {
     document.querySelector('#p_main').style.display = "block";
     document.querySelector('#p1').style.display = "block";
 
-    // Hide other paragraphs initially
+    // Hide other paragraphs initially and then switch out dependent on current subject presented
     document.querySelector('#p_stance').style.display = "none";
     document.querySelector('#p_sentiment').style.display = "none";
     document.querySelector('#p_aggressiveness').style.display = "none";
@@ -88,11 +92,26 @@ nextButton.onclick = function() {
     }
 
 
-
+    //changes title text so that readers comprehend what subject they are on
     if (currentSubject === "None") {
         document.querySelector('.top-bar-title').textContent = "No Subject Selected";
     } else {
         document.querySelector('.top-bar-title').textContent = "Current Subject: " + currentSubject;
+    }
+
+
+    // Check if the current subject is "Aggressiveness" and hide the button
+    if (currentSubject === "Aggressiveness") {
+        nextButton.style.display = "none";
+    } else {
+        nextButton.style.display = "block"; // Make sure it's visible for other subjects
+    }
+
+    // Check if the current subject is "None" and hide the "Back" button
+    if (currentSubject === "None") {
+        backButton.style.display = "none";
+    } else {
+        backButton.style.display = "block"; // Make sure it's visible for other subjects
     }
 
     //console.log("NEW SUBJECT SELECTED:", currentSubject);
@@ -132,14 +151,25 @@ backButton.onclick = function() {
         document.querySelector('#p1').style.display = "none";
     }
 
-
-
-
-
     if (currentSubject === "None") {
         document.querySelector('.top-bar-title').textContent = "No Subject Selected";
     } else {
         document.querySelector('.top-bar-title').textContent = "Current Subject: " + currentSubject;
+    }
+
+
+    // Check if the current subject is "Aggressiveness" and hide the button
+    if (currentSubject === "Aggressiveness") {
+        nextButton.style.display = "none";
+    } else {
+        nextButton.style.display = "block"; // Make sure it's visible for other subjects
+    }
+
+    // Check if the current subject is "None" and hide the "Back" button
+    if (currentSubject === "None") {
+        backButton.style.display = "none";
+    } else {
+        backButton.style.display = "block"; // Make sure it's visible for other subjects
     }
 
     //console.log("NEW SUBJECT SELECTED:", currentSubject);

--- a/pages/p3_intro.html
+++ b/pages/p3_intro.html
@@ -22,26 +22,21 @@
                             Google Trends and Twitter. Our project captures the shift in climate-related topics over
                             time, like how "Global Warming" has made way for "Climate Action" in public
                             consciousness.</p>
-
-                        <p id="topic-emmett" class="text-justify ">Now, you've chosen to focus on <span class="bold palette-bright-green"
+                        <p class="topic-emmett text-justify ">Now, you've chosen to focus on <span class="bold palette-bright-green"
                         > "Human
                             Impact." </span>
                         In this
                         section,
                             we'll zoom in on specific
                             climate conversations, particularly those around activism and its effects on society. Expect to see how these discussions have grown and transformed across digital platforms.</p>
-                        <p id="topic-herbie" class="text-justify d-none">Now, you've chosen to concentrate on <span class="bold palette-bright-green"
+                        <p class="topic-herbie text-justify" style="display: none;">Now, you've chosen to concentrate on <span class="bold palette-bright-green"
                         >"Gas Emissions."</span> In this segment, we'll delve into the critical social and governmental dialogue surrounding emissions. Anticipate an in-depth exploration of how these conversations have evolved and intensified within the realm of environmental stewardship.</p>
-                        <p id="topic-sunny" class="text-justify d-none">Now, you've selected <span class="bold palette-bright-green"
+                        <p class="topic-sunny text-justify" style="display: none;">Now, you've selected <span class="bold palette-bright-green"
                         >"Global Warming" </span>. In this segment, we'll explore the critical social and governmental
                             dialogue surrounding global warming. Prepare to engage with the narrative of global warming's challenges and the collective efforts of governments to mitigate its impact on our planet.</p>
-                        <p id="topic-oscar" class="text-justify d-none">Now, you've selected <span class="bold palette-bright-green"
+                        <p class="topic-oscar text-justify" style="display: none;">Now, you've selected <span class="bold palette-bright-green"
                         >"Weather & Pollution" </span> to address the pressing challenge of pollution and shifting
                             weather. In this discourse, we'll navigate through the complexities of environmental conservations, focusing on the imperative to safeguard nature. Gear up to traverse the landscape of ecological protection and the significant strides made towards cleaner, healthier ecosystems.</p>
-
-
-
-
                         <p class="text-justify ">Join me as we uncover the human stories behind the data, bridging the gap between global
                             trends and individual experiences. Let's dive into the heart of climate change's impact on humanity!</p>   </div>
                 </div>

--- a/pages/vis2_main.html
+++ b/pages/vis2_main.html
@@ -1,17 +1,18 @@
 <div class="section">
-    <div class="card mx-auto mb-2 py-3" id="card-back-next">
-        <div class="d-flex justify-content-around">
-            <div>
-                <button id="vis2-back-button" class="btn btn-primary ">Back</button>
-            </div>
-            <div class="col-md-8 text-center">
-                <span class="top-bar-title">No Subject Selected</span>
-            </div>
-            <div>
-                <button id="vis2-next-button" class="btn btn-primary">Next</button>
+        <!--MAKES TITLE CARD AREA WITH BACK AND NEXT BUTTON-->
+        <div class="card mx-auto mb-2 py-3" id="card-back-next">
+            <div class="row">
+                <div class="col-md-3">
+                    <button id="vis2-back-button" class="btn btn-primary">View Previous Subject</button>
+                </div>
+                <div class="col-md-6 text-center">
+                    <span class="top-bar-title palette-green">No Subject Selected</span>
+                </div>
+                <div class="col-md-3">
+                    <button id="vis2-next-button" class="btn btn-primary">View Next Subject</button>
+                </div>
             </div>
         </div>
-    </div>
 
     <div class="container-fluid" id="vis2_container">
         <div class="card mx-auto vis2-card-area shadow">
@@ -79,6 +80,15 @@
                                 <span id="p_aggressiveness" style="display: none">Aggressiveness of Tweets: It measures the level of aggressiveness in tweets, offering insights into the intensity and nature of climate change debates on social media.</span>
 <!--                                <p>REMINDER TO CITE: If you use the dataset, cite the papers: https://doi.org/10.1016/j.eswa.2022.117541 and https://doi.org/10.1371/journal.pone.0274213</p>-->
                             </div>
+                        </div>
+                        <div class="row">
+                            <p class="topic-emmett"> emmet </p>
+                            <p class="topic-herbie"> herbie </p>
+                            <p class="topic-sunny"> sunny </p>
+                            <p class="topic-oscar"> oscar </p>
+                            <img src="images/emojis/emmett.png" class="user-topic-image" id="vis2-image" height="100%" width="100%"/>
+<!--                            <p>Hi, I'm <span class="emojiName bold">Emmett</span> your tour guide today!</p>-->
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
We want some paragraphs to only appear when a specific Emoji (topic) is selected.
There are 4 of these paragraphs in `p3_intro.html`. Previously these paragraph elements used id's to indicate whether they should appear or not depending on which Emoji was selected. This PR modifies `UserTopicService.js` so that classnames can be used instead of ids. Using Classes means we can make any number of topic-specific paragraphs, instead of being limited to one per topic.

This PR also includes some changes to the next/back buttons in vis2_main.